### PR TITLE
Add recall endpoint with flashcards and scheduling

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+import json
 
-from fastapi import Depends, FastAPI
-from pydantic import BaseModel
+from fastapi import Depends, FastAPI, HTTPException
+from pydantic import BaseModel, ValidationError
 from collections.abc import Iterator
 from sqlalchemy.orm import Session
 
 from .db import SessionLocal, init_db
-from . import models
+from . import models, scheduler, utils
+from .llm import MockLLM
 
 init_db()
 
@@ -26,6 +28,25 @@ def get_db() -> Iterator[Session]:
 class UploadRequest(BaseModel):
     topic: str
     content: str
+
+
+class RecallRequest(BaseModel):
+    topic: str
+    recall_text: str
+
+
+class FlashcardItem(BaseModel):
+    front: str
+    back: str
+
+
+class LLMResponse(BaseModel):
+    score: int
+    feedback: str
+    flashcards: list[FlashcardItem]
+
+
+llm = MockLLM()
 
 
 @app.get("/health")
@@ -58,3 +79,66 @@ async def due_topics(db: Session = Depends(get_db)) -> list[str]:
     now = datetime.utcnow().isoformat()
     rows = db.query(models.TopicSchedule).filter(models.TopicSchedule.next_review <= now).all()
     return [r.topic for r in rows]
+
+
+@app.post("/recall")
+async def recall(req: RecallRequest, db: Session = Depends(get_db)) -> dict[str, str | int]:
+    material = db.query(models.StudyMaterial).filter_by(topic=req.topic).first()
+    if material is None:
+        raise HTTPException(status_code=404, detail="Topic not found")
+
+    prompt = f"{material.content}\n---\n{req.recall_text}"
+    raw_resp = llm.score(prompt)
+    try:
+        parsed = LLMResponse(**raw_resp)
+    except ValidationError as e:  # pragma: no cover - schema errors are unlikely
+        raise HTTPException(status_code=500, detail="Invalid LLM response") from e
+
+    now = datetime.utcnow()
+    now_iso = now.isoformat()
+    history = models.RecallHistory(
+        topic=req.topic,
+        recall_text=req.recall_text,
+        feedback_json=json.dumps(raw_resp),
+        score=parsed.score,
+        created_at=now_iso,
+    )
+    db.add(history)
+
+    schedule = db.query(models.TopicSchedule).filter_by(topic=req.topic).first()
+    if schedule is None:
+        schedule = models.TopicSchedule(
+            topic=req.topic,
+            interval_days=1,
+            next_review=now_iso,
+        )
+        db.add(schedule)
+    next_int = scheduler.next_interval(schedule.interval_days, parsed.score)
+    schedule.interval_days = next_int
+    schedule.last_review = now_iso
+    schedule.next_review = (now + timedelta(days=next_int)).isoformat()
+
+    cards_added = 0
+    for card in parsed.flashcards:
+        h = utils.card_hash(card.front, card.back)
+        exists = db.query(models.Flashcard).filter_by(front_back_sha256=h).first()
+        if exists:
+            continue
+        db.add(
+            models.Flashcard(
+                topic=req.topic,
+                front=card.front,
+                back=card.back,
+                front_back_sha256=h,
+                created_at=now_iso,
+            )
+        )
+        cards_added += 1
+
+    db.commit()
+    return {
+        "feedback": parsed.feedback,
+        "score": parsed.score,
+        "cards_added": cards_added,
+        "next_review": schedule.next_review,
+    }

--- a/tests/test_recall_endpoint.py
+++ b/tests/test_recall_endpoint.py
@@ -1,0 +1,71 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.db import Base, engine, SessionLocal
+from app import models
+from app.llm import MockLLM
+
+
+client = TestClient(app)
+
+
+def setup_module() -> None:
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def teardown_module() -> None:
+    Base.metadata.drop_all(bind=engine)
+
+
+def test_recall_missing_topic() -> None:
+    resp = client.post("/recall", json={"topic": "unknown", "recall_text": "test"})
+    assert resp.status_code == 404
+
+
+def test_recall_flow() -> None:
+    # Upload initial study material
+    up = client.post("/upload", json={"topic": "Alpha", "content": "content"})
+    assert up.status_code == 200
+
+    class CustomLLM(MockLLM):
+        def score(self, prompt: str) -> dict:  # type: ignore[override]
+            return {
+                "score": 80,
+                "feedback": "Nice",
+                "flashcards": [
+                    {"front": "Q1", "back": "A1"},
+                ],
+            }
+
+    # Swap in our deterministic LLM
+    import app.main as main
+
+    main.llm = CustomLLM()
+
+    resp = client.post(
+        "/recall", json={"topic": "Alpha", "recall_text": "some recall"}
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["score"] == 80
+    assert data["feedback"] == "Nice"
+    assert data["cards_added"] == 1
+    assert "next_review" in data
+
+    db = SessionLocal()
+    try:
+        # A history entry was added
+        hist = db.query(models.RecallHistory).filter_by(topic="Alpha").all()
+        assert len(hist) == 1
+
+        # Schedule updated based on score
+        sched = db.query(models.TopicSchedule).filter_by(topic="Alpha").first()
+        assert sched is not None and sched.interval_days == 2
+
+        # Flashcard persisted
+        cards = db.query(models.Flashcard).filter_by(topic="Alpha").all()
+        assert len(cards) == 1
+    finally:
+        db.close()
+


### PR DESCRIPTION
## Summary
- add Pydantic models and MockLLM-driven `/recall` endpoint with scheduling and flashcard persistence
- include tests for recall flow and missing topics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0fa3ac88883289bd1688aaeb8fc34