### PR TITLE
feat: add gemini llm client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,6 @@
 LLM_PROVIDER=mock
-OPENAI_API_KEY=sk-...
 GEMINI_API_KEY=...
-MODEL_NAME=gpt-4o-mini
+MODEL_NAME=gemini-1.5-flash
 ANKI_CONNECT_URL=http://localhost:8765
 ANKI_DECK_NAME=Pharmacy_Recall_AI
 APP_AUTH_TOKEN=

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You are an expert full‑stack engineer tasked with producing a production‑rea
 * **Language**: Python 3.11+.
 * **Framework**: Prefer **FastAPI** for built‑in OpenAPI and pydantic. If you use Flask, replicate equivalent validation with `pydantic`/`marshmallow`. FastAPI is recommended.
 * **DB**: SQLite (`study_app.db`) using `sqlite3` or `sqlalchemy` (recommended) with WAL mode enabled. Include indices and constraints.
-* **LLM Provider**: Pluggable interface supporting OpenAI and Gemini. Use official client libraries. Hide keys in environment variables. Provide a no‑network `MockLLM` for tests.
+* **LLM Provider**: Gemini with a pluggable interface (plus a no‑network `MockLLM` for tests). Use the official client library and hide keys in environment variables.
 * **Anki**: AnkiConnect at `http://localhost:8765`. Create deck if missing. Prevent duplicates.
 * **Time**: Store UTC timestamps as ISO 8601. Convert to local time only in UI.
 * **Security**: Input validation, request size limits, CORS config, API key loading from env, simple auth hook (optional token) that can be toggled via env.
@@ -32,10 +32,9 @@ You are an expert full‑stack engineer tasked with producing a production‑rea
 
 Provide `.env.example` and config loader.
 
-* `LLM_PROVIDER=openai|gemini|mock`
-* `OPENAI_API_KEY=...` (if provider=openai)
-* `GEMINI_API_KEY=...` (if provider=gemini)
-* `MODEL_NAME=gpt-4o-mini` (or provider‑appropriate default)
+* `LLM_PROVIDER=gemini|mock`
+* `GEMINI_API_KEY=...`
+* `MODEL_NAME=gemini-1.5-flash`
 * `ANKI_CONNECT_URL=http://localhost:8765`
 * `ANKI_DECK_NAME=Pharmacy_Recall_AI`
 * `APP_AUTH_TOKEN=` (optional; if set, require `Authorization: Bearer <token>`)
@@ -286,7 +285,6 @@ app/
   llm/
     __init__.py
     provider.py        # interface + factory
-    openai_provider.py
     gemini_provider.py
     mock_provider.py
   anki.py              # AnkiConnect client + dedupe

--- a/app/config.py
+++ b/app/config.py
@@ -4,10 +4,9 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     """Application settings loaded from environment variables."""
 
-    llm_provider: str = "mock"
-    openai_api_key: str | None = None
+    llm_provider: str = "mock"  # "gemini" or "mock"
     gemini_api_key: str | None = None
-    model_name: str = "gpt-4o-mini"
+    model_name: str = "gemini-1.5-flash"
     anki_connect_url: str = "http://localhost:8765"
     anki_deck_name: str = "Pharmacy_Recall_AI"
     app_auth_token: str | None = None

--- a/app/llm.py
+++ b/app/llm.py
@@ -1,8 +1,23 @@
-"""Minimal LLM client abstractions."""
+"""LLM client implementations for the study app.
+
+This module provides a small abstraction layer around language models.  It
+ships with a ``MockLLM`` used in tests and a ``GeminiLLM`` implementation that
+calls Google's Gemini models.  A ``build_llm`` helper instantiates the desired
+client based on application settings.
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+import json
+from typing import Protocol, TYPE_CHECKING
+
+
+class LLM(Protocol):
+    """Protocol that all LLM clients must satisfy."""
+
+    def score(self, prompt: str) -> dict:
+        """Return a parsed JSON dict from the model for the given prompt."""
 
 
 @dataclass
@@ -16,3 +31,61 @@ class MockLLM:
             "feedback": "Great job!",
             "flashcards": [],
         }
+
+
+@dataclass
+class GeminiLLM:
+    """LLM client for Google's Gemini models."""
+
+    api_key: str
+    model_name: str
+
+    def __post_init__(self) -> None:
+        try:  # Lazy import so tests can run without the dependency installed
+            import google.generativeai as genai
+        except Exception as exc:  # pragma: no cover - exercised only when missing
+            raise RuntimeError("google-generativeai package not installed") from exc
+
+        genai.configure(api_key=self.api_key)
+        self._model = genai.GenerativeModel(self.model_name)
+
+    def score(self, prompt: str) -> dict:
+        """Send the prompt to Gemini and parse the JSON response."""
+
+        response = self._model.generate_content(prompt)
+        text = getattr(response, "text", None)
+        if not text:  # Fallback if the client returns candidates/parts structure
+            candidate = getattr(response, "candidates", [None])[0]
+            if candidate is not None:
+                parts = getattr(candidate.content, "parts", [])
+                if parts:
+                    text = getattr(parts[0], "text", None)
+        if not text:
+            raise RuntimeError("No text returned from Gemini")
+
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("Gemini response was not valid JSON") from exc
+
+
+if TYPE_CHECKING:  # pragma: no cover - for type checkers only
+    from .config import Settings
+
+
+def build_llm(settings: "Settings" | None = None) -> LLM:
+    """Factory to create an LLM client based on configured provider."""
+
+    if settings is None:
+        from .config import settings as cfg
+        settings = cfg
+
+    provider = settings.llm_provider.lower()
+    if provider == "gemini":
+        if not settings.gemini_api_key:
+            raise RuntimeError("Gemini API key not configured")
+        return GeminiLLM(api_key=settings.gemini_api_key, model_name=settings.model_name)
+
+    # Default to the mock implementation for tests or local development
+    return MockLLM()
+

--- a/app/main.py
+++ b/app/main.py
@@ -10,7 +10,8 @@ from sqlalchemy.orm import Session
 
 from .db import SessionLocal, init_db
 from . import models, scheduler, utils
-from .llm import MockLLM
+from .llm import build_llm
+from .config import settings
 
 init_db()
 
@@ -46,7 +47,7 @@ class LLMResponse(BaseModel):
     flashcards: list[FlashcardItem]
 
 
-llm = MockLLM()
+llm = build_llm(settings)
 
 
 @app.get("/health")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 fastapi
 sqlalchemy
 pydantic
+pydantic-settings
 python-dotenv
 uvicorn
+google-generativeai
+httpx


### PR DESCRIPTION
## Summary
- add Gemini-powered LLM client and factory for selecting providers
- drop OpenAI/GPT config and docs, update environment variables
- include google-generativeai and supporting deps

## Testing
- `pip install google-generativeai==0.5.2`
- `pip install httpx`
- `pip install pydantic-settings`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0fb9d527883288c2d3af00ffd77e0